### PR TITLE
feat: Add PHP 8.4 support

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '8.2'
+          - '8.3'
         dependencies:
           - 'highest'
 

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '8.2'
+          - '8.3'
         dependencies:
           - 'highest'
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '8.2'
+          - '8.3'
         dependencies:
           - 'highest'
 
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '8.2'
+          - '8.3'
         dependencies:
           - 'highest'
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,6 +17,7 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
         dependencies:
           - 'lowest'
           - 'highest'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Results
 [![Packagist][packagist-version-badge]][packagist-url]
 [![License][license-badge]][license-url]
 
-[php-badge]: https://img.shields.io/badge/php-8.1%20to%208.3-777bb3.svg
+[php-badge]: https://img.shields.io/badge/php-8.1%20to%208.4-777bb3.svg
 [php-url]: https://coveralls.io/github/hereldar/php-results
 [codecov-badge]: https://img.shields.io/codecov/c/github/hereldar/php-results
 [codecov-url]: https://app.codecov.io/gh/hereldar/php-results

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,15 @@
         }
     ],
     "require": {
-        "php": "^8.1.17|^8.2.4|^8.3.0"
+        "php": "^8.1.17|^8.2.4|^8.3.0|^8.4.0"
     },
     "require-dev": {
         "hereldar/coding-style": "^0.1.2",
         "hereldar/faker-helper": "^0.1.1",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^10.1",
-        "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.23.0"
+        "psalm/plugin-phpunit": "^0.19.5",
+        "vimeo/psalm": "^6.12.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Error.php
+++ b/src/Error.php
@@ -6,6 +6,7 @@ namespace Hereldar\Results;
 
 use Closure;
 use Hereldar\Results\Interfaces\Resultlike;
+use Override;
 use RuntimeException;
 use Throwable;
 
@@ -63,11 +64,13 @@ final class Error implements Resultlike
      *
      * @psalm-suppress MoreSpecificImplementedParamType
      */
+    #[Override]
     public function andThen(Ok|self|Closure $result): static
     {
         return $this;
     }
 
+    #[Override]
     public function hasValue(): bool
     {
         return (null !== $this->value);
@@ -76,6 +79,7 @@ final class Error implements Resultlike
     /**
      * @return true
      */
+    #[Override]
     public function isError(): bool
     {
         return true;
@@ -84,6 +88,7 @@ final class Error implements Resultlike
     /**
      * @return false
      */
+    #[Override]
     public function isOk(): bool
     {
         return false;
@@ -96,6 +101,7 @@ final class Error implements Resultlike
      *
      * @psalm-suppress InvalidTemplateParam
      */
+    #[Override]
     public function onFailure(Closure $action): static
     {
         $action($this->value);
@@ -108,6 +114,7 @@ final class Error implements Resultlike
      *
      * @return $this
      */
+    #[Override]
     public function onSuccess(Closure $action): static
     {
         return $this;
@@ -123,6 +130,7 @@ final class Error implements Resultlike
      * @psalm-suppress MixedInferredReturnType
      * @psalm-suppress MixedReturnStatement
      */
+    #[Override]
     public function or(mixed $value): mixed
     {
         if ($value instanceof Closure) {
@@ -132,6 +140,7 @@ final class Error implements Resultlike
         return $value;
     }
 
+    #[Override]
     public function orDie(int|string|null $status = null): never
     {
         if (null !== $status) {
@@ -157,6 +166,7 @@ final class Error implements Resultlike
      * @psalm-suppress MixedReturnStatement
      * @psalm-suppress InvalidReturnStatement
      */
+    #[Override]
     public function orElse(Ok|self|Closure $result): Ok|self
     {
         if ($result instanceof Closure) {
@@ -172,6 +182,7 @@ final class Error implements Resultlike
      *
      * @psalm-suppress UndefinedDocblockClass
      */
+    #[\Override]
     public function orFail(): never
     {
         if ($this->value instanceof Throwable) {
@@ -184,6 +195,7 @@ final class Error implements Resultlike
     /**
      * @return false
      */
+    #[Override]
     public function orFalse(): bool
     {
         return false;
@@ -194,6 +206,7 @@ final class Error implements Resultlike
      *
      * @psalm-suppress  InvalidReturnStatement
      */
+    #[Override]
     public function orNull(): mixed
     {
         return null;
@@ -210,6 +223,7 @@ final class Error implements Resultlike
      * @psalm-suppress UndefinedDocblockClass
      * @psalm-suppress InvalidTemplateParam
      */
+    #[Override]
     public function orThrow(Throwable|Closure $exception): never
     {
         if ($exception instanceof Closure) {
@@ -222,6 +236,7 @@ final class Error implements Resultlike
     /**
      * @return E
      */
+    #[Override]
     public function value(): mixed
     {
         return $this->value;

--- a/src/Ok.php
+++ b/src/Ok.php
@@ -6,6 +6,7 @@ namespace Hereldar\Results;
 
 use Closure;
 use Hereldar\Results\Interfaces\Resultlike;
+use Override;
 use Throwable;
 
 /**
@@ -68,6 +69,7 @@ final class Ok implements Resultlike
      * @psalm-suppress MixedReturnStatement
      * @psalm-suppress InvalidReturnStatement
      */
+    #[Override]
     public function andThen(self|Error|Closure $result): self|Error
     {
         if ($result instanceof Closure) {
@@ -77,6 +79,7 @@ final class Ok implements Resultlike
         return $result;
     }
 
+    #[Override]
     public function hasValue(): bool
     {
         return (null !== $this->value);
@@ -85,6 +88,7 @@ final class Ok implements Resultlike
     /**
      * @return false
      */
+    #[Override]
     public function isError(): bool
     {
         return false;
@@ -93,6 +97,7 @@ final class Ok implements Resultlike
     /**
      * @return true
      */
+    #[Override]
     public function isOk(): bool
     {
         return true;
@@ -103,6 +108,7 @@ final class Ok implements Resultlike
      *
      * @return $this
      */
+    #[Override]
     public function onFailure(Closure $action): static
     {
         return $this;
@@ -115,6 +121,7 @@ final class Ok implements Resultlike
      *
      * @psalm-suppress InvalidTemplateParam
      */
+    #[Override]
     public function onSuccess(Closure $action): static
     {
         $action($this->value);
@@ -129,6 +136,7 @@ final class Ok implements Resultlike
      *
      * @return T
      */
+    #[Override]
     public function or(mixed $value): mixed
     {
         return $this->value;
@@ -137,6 +145,7 @@ final class Ok implements Resultlike
     /**
      * @return T
      */
+    #[Override]
     public function orDie(int|string|null $status = null): mixed
     {
         return $this->value;
@@ -152,6 +161,7 @@ final class Ok implements Resultlike
      *
      * @psalm-suppress MoreSpecificImplementedParamType
      */
+    #[Override]
     public function orElse(self|Error|Closure $result): static
     {
         return $this;
@@ -160,6 +170,7 @@ final class Ok implements Resultlike
     /**
      * @return T
      */
+    #[Override]
     public function orFail(): mixed
     {
         return $this->value;
@@ -168,6 +179,7 @@ final class Ok implements Resultlike
     /**
      * @return T
      */
+    #[Override]
     public function orFalse(): mixed
     {
         return $this->value;
@@ -176,6 +188,7 @@ final class Ok implements Resultlike
     /**
      * @return T
      */
+    #[Override]
     public function orNull(): mixed
     {
         return $this->value;
@@ -190,6 +203,7 @@ final class Ok implements Resultlike
      *
      * @psalm-suppress MoreSpecificImplementedParamType
      */
+    #[Override]
     public function orThrow(Throwable|Closure $exception): mixed
     {
         return $this->value;
@@ -198,6 +212,7 @@ final class Ok implements Resultlike
     /**
      * @return T
      */
+    #[Override]
     public function value(): mixed
     {
         return $this->value;

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -8,6 +8,7 @@ use Exception;
 use Hereldar\Results\Error;
 use Hereldar\Results\Ok;
 use LogicException;
+use Override;
 use RuntimeException;
 use Throwable;
 use UnexpectedValueException;
@@ -30,6 +31,7 @@ final class ErrorTest extends TestCase
     /** @var Ok<null> */
     private Ok $ok;
 
+    #[Override]
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/OkTest.php
+++ b/tests/OkTest.php
@@ -7,6 +7,7 @@ namespace Hereldar\Results\Tests;
 use Exception;
 use Hereldar\Results\Error;
 use Hereldar\Results\Ok;
+use Override;
 use Throwable;
 use UnexpectedValueException;
 
@@ -25,6 +26,7 @@ final class OkTest extends TestCase
     /** @var Error<null> */
     private Error $error;
 
+    #[Override]
     protected function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
- Run tests and static analysis on PHP 8.4
- Update README.md to include PHP 8.4 as a supported version
- Update GitHub Actions to use PHP 8.3 instead of 8.2
- Update unit tests to run on PHP 8.1, 8.2, 8.3 and 8.4
- Update version of Psalm
- Add Override attribute